### PR TITLE
BUG: Running std dev or mean projection crashes the application

### DIFF
--- a/VolumeProjection/VolumeProjection.py
+++ b/VolumeProjection/VolumeProjection.py
@@ -215,7 +215,7 @@ class VolumeProjectionLogic(ScriptedLoadableModuleLogic):
         projectionType = itk.MaximumProjectionImageFilter()
         logging.info('Ran Maximum Projection along %s', self.axis_dict[axis])
         projectionType.SetProjectionDimension(axis)
-        proj_array = itk.GetArrayViewFromImage(projectionType.Execute(image_data))
+        proj_array = itk.GetArrayFromImage(projectionType.Execute(image_data))
         del projectionType
         return proj_array
 
@@ -224,7 +224,7 @@ class VolumeProjectionLogic(ScriptedLoadableModuleLogic):
         projectionType = itk.MinimumProjectionImageFilter()
         logging.info('Ran Minimum Projection along %s', self.axis_dict[axis])
         projectionType.SetProjectionDimension(axis)
-        proj_array = itk.GetArrayViewFromImage(projectionType.Execute(image_data))
+        proj_array = itk.GetArrayFromImage(projectionType.Execute(image_data))
         del projectionType
         return proj_array
 
@@ -234,7 +234,7 @@ class VolumeProjectionLogic(ScriptedLoadableModuleLogic):
         # TODO: check data types of inputs/conversions
         logging.info('Ran Mean Projection along %s', self.axis_dict[axis])
         projectionType.SetProjectionDimension(axis)
-        proj_array = itk.GetArrayViewFromImage(projectionType.Execute(image_data))
+        proj_array = itk.GetArrayFromImage(projectionType.Execute(image_data))
         del projectionType
         return proj_array
 
@@ -244,7 +244,7 @@ class VolumeProjectionLogic(ScriptedLoadableModuleLogic):
         # TODO: check data types of inputs/conversions
         logging.info('Ran Standard Deviation Projection along %s', self.axis_dict[axis])
         projectionType.SetProjectionDimension(axis)
-        proj_array = itk.GetArrayViewFromImage(projectionType.Execute(image_data))
+        proj_array = itk.GetArrayFromImage(projectionType.Execute(image_data))
         del projectionType
         return proj_array
 


### PR DESCRIPTION
This should solve the issues with running std dev and mean projections. I'm not exactly clear on the why here, since min and max were working fine, but I assume it has to do with how `sitk.GetArrayViewFromImage` returns an immutable array view to the data, whereas `sitk.GetArrayFromImage` returns a copy of the data which can be modified. http://insightsoftwareconsortium.github.io/SimpleITK-Notebooks/Python_html/03_Image_Details.html

If you try out the code for `runStdDev` in slicer's python interpreter, the application will crash when you try to access the array from `itk.GetArrayViewFromImage(projectionType.Execute(image_data))`.